### PR TITLE
Contract interface additions for game implementation

### DIFF
--- a/contracts/PepemonBattle.sol
+++ b/contracts/PepemonBattle.sol
@@ -9,7 +9,7 @@ import "./lib/ChainLinkRngOracle.sol";
 
 contract PepemonBattle is AdminRole {
     
-    event BattleCreated(uint256 battleId, address player1Addr, address player2Addr);
+    event BattleCreated(address indexed player1Addr, address indexed player2Addr, uint256 battleId);
 
     mapping (uint => uint) public battleIdRNGSeed;
 
@@ -150,7 +150,7 @@ contract PepemonBattle is AdminRole {
         //Write battle into mapping
         battles[_nextBattleId] = newBattle;
         //Emit event
-        emit BattleCreated(_nextBattleId, p1Addr, p2Addr);
+        emit BattleCreated(p1Addr, p2Addr, _nextBattleId);
         _nextBattleId++;
     }
 

--- a/contracts/PepemonCardDeck.sol
+++ b/contracts/PepemonCardDeck.sol
@@ -205,6 +205,10 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
     }
 
     // VIEWS
+    function getDeckCount(address player) public view returns (uint256) {
+        return playerToDecks[player].length;
+    }
+
     function getBattleCardInDeck(uint256 _deckId) public view returns (uint256) {
         return decks[_deckId].battleCardId;
     }


### PR DESCRIPTION
- Updated BattleCreated event to allow filtering by player address
  This is required for matchmaking - players will wait for events with their address in either player1Addr or player2Addr before proceeding to the battle scene in the game.

- Added getDeckCount view to PepemonCardDeck so player-owned deck IDs can be listed
