### PR TITLE
Removed minimum deck card count check when removing cards

### DIFF
--- a/contracts/PepemonCardDeck.sol
+++ b/contracts/PepemonCardDeck.sol
@@ -64,10 +64,11 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
 
     // MODIFIERS
     modifier sendersDeck(uint256 _deckId) {
-        require(msg.sender == ownerOf(_deckId));
+        require(msg.sender == ownerOf(_deckId), "PepemonCardDeck: Not your deck");
         _;
     }
 
+    // PUBLIC METHODS
     function setBattleCardAddress(address _battleCardAddress) public onlyOwner {
         battleCardAddress = _battleCardAddress;
     }
@@ -90,7 +91,7 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
         nextDeckId = nextDeckId.add(1);
     }
 
-    function addBattleCardToDeck(uint256 deckId, uint256 battleCardId) public {
+    function addBattleCardToDeck(uint256 deckId, uint256 battleCardId) public sendersDeck(deckId) {
         require(
             PepemonFactory(battleCardAddress).balanceOf(msg.sender, battleCardId) >= 1,
             "PepemonCardDeck: Don't own battle card"
@@ -106,9 +107,7 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
         returnBattleCardFromDeck(oldBattleCardId);
     }
 
-    function removeBattleCardFromDeck(uint256 _deckId) public {
-        require(ownerOf(_deckId) == msg.sender, "PepemonCardDeck: Not your deck");
-
+    function removeBattleCardFromDeck(uint256 _deckId) public sendersDeck(_deckId) {
         uint256 oldBattleCardId = decks[_deckId].battleCardId;
 
         decks[_deckId].battleCardId = 0;
@@ -116,13 +115,13 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
         returnBattleCardFromDeck(oldBattleCardId);
     }
 
-    function addSupportCardsToDeck(uint256 deckId, SupportCardRequest[] memory supportCards) public {
+    function addSupportCardsToDeck(uint256 deckId, SupportCardRequest[] memory supportCards) public sendersDeck(deckId) {
         for (uint256 i = 0; i < supportCards.length; i++) {
             addSupportCardToDeck(deckId, supportCards[i].supportCardId, supportCards[i].amount);
         }
     }
 
-    function removeSupportCardsFromDeck(uint256 _deckId, SupportCardRequest[] memory _supportCards) public {
+    function removeSupportCardsFromDeck(uint256 _deckId, SupportCardRequest[] memory _supportCards) public sendersDeck(_deckId) {
         for (uint256 i = 0; i < _supportCards.length; i++) {
             removeSupportCardFromDeck(_deckId, _supportCards[i].supportCardId, _supportCards[i].amount);
         }

--- a/contracts/PepemonCardDeck.sol
+++ b/contracts/PepemonCardDeck.sol
@@ -160,31 +160,11 @@ contract PepemonCardDeck is ERC721, ERC1155Holder, Ownable {
         PepemonFactory(supportCardAddress).safeTransferFrom(msg.sender, address(this), _supportCardId, _amount, "");
     }
 
-  /*  function removeSupportCardTypeFromDeck(uint256 _deckId, uint256 _supportCardId) internal {
-        Deck storage deck = decks[_deckId];
-        SupportCardType storage supportCardType = decks[_deckId].supportCardTypes[_supportCardId];
-        require(deck.supportCardCount - supportCardType.count >= MIN_SUPPORT_CARDS, "PepemonCardDeck: Deck underflow");
-
-        uint256 cardTypeToRemove = supportCardType.pointer;
-
-        if (deck.supportCardTypeList.length > 1 && cardTypeToRemove != deck.supportCardTypeList.length - 1) {
-            // last card type in list
-            uint256 rowToMove = deck.supportCardTypeList[deck.supportCardTypeList.length - 1];
-
-            // swap delete row with row to move
-            decks[_deckId].supportCardTypes[rowToMove].pointer = cardTypeToRemove;
-        }
-
-        decks[_deckId].supportCardTypeList.pop();
-        delete decks[_deckId].supportCardTypes[cardTypeToRemove];
-    }*/
-
     function removeSupportCardFromDeck(
         uint256 _deckId,
         uint256 _supportCardId,
         uint256 _amount
     ) internal {
-        require(decks[_deckId].supportCardCount - _amount >= MIN_SUPPORT_CARDS, "PepemonCardDeck: Deck underflow");
         SupportCardType storage supportCardList = decks[_deckId].supportCardTypes[_supportCardId];
         supportCardList.count = supportCardList.count.sub(_amount);
 

--- a/test/DeckTest.ts
+++ b/test/DeckTest.ts
@@ -87,10 +87,10 @@ describe('::Deck', () => {
     });
 
     describe('Permissions', async () => {
-      it("Should prevent adding cards you don't have", async () => {
-        await battleCard.mock.balanceOf.withArgs(bob.address, 1).returns(0);
+      it("Should prevent adding battle cards you don't have", async () => {
+        await battleCard.mock.balanceOf.withArgs(alice.address, 1).returns(0);
 
-        await expect(bobSignedDeck.addBattleCardToDeck(1, 1)).to.be.revertedWith(
+        await expect(deck.addBattleCardToDeck(1, 1)).to.be.revertedWith(
           "PepemonCardDeck: Don't own battle card"
         );
       });
@@ -258,10 +258,10 @@ describe('::Deck', () => {
     });
 
     describe('Permissions', async () => {
-      it("Should prevent adding cards you don't have", async () => {
-        await supportCard.mock.balanceOf.withArgs(bob.address, 20).returns(0);
+      it("Should prevent adding support cards you don't have", async () => {
+        await supportCard.mock.balanceOf.withArgs(alice.address, 20).returns(0);
 
-        await expect(bobSignedDeck.addSupportCardsToDeck(1, [{supportCardId: 20, amount: 1}])).to.be.revertedWith(
+        await expect(deck.addSupportCardsToDeck(1, [{supportCardId: 20, amount: 1}])).to.be.revertedWith(
           "PepemonCardDeck: You don't have enough of this card"
         );
       });

--- a/test/DeckTest.ts
+++ b/test/DeckTest.ts
@@ -94,8 +94,29 @@ describe('::Deck', () => {
         );
       });
 
+      it("Should prevent adding a battle card to a deck which you don't own", async () => {
+        await battleCard.mock.balanceOf.withArgs(bob.address, 1).returns(1);
+        await expect(bobSignedDeck.addBattleCardToDeck(1, 1)).to.be.revertedWith(
+          'PepemonCardDeck: Not your deck'
+        );
+      });
+
       it("Should prevent removing a battle card from a deck which you don't own", async () => {
         await expect(bobSignedDeck.removeBattleCardFromDeck(1)).to.be.revertedWith(
+          'PepemonCardDeck: Not your deck'
+        );
+      });
+
+      it("Should prevent adding a support card to a deck which you don't own", async () => {
+        await supportCard.mock.balanceOf.withArgs(bob.address, 20).returns(1);
+        await expect(bobSignedDeck.addSupportCardsToDeck(1, [{supportCardId: 20, amount: 1}])).to.be.revertedWith(
+          'PepemonCardDeck: Not your deck'
+        );
+      });
+
+      it("Should prevent removing a support card from a deck which you don't own", async () => {
+        await deck.addSupportCardsToDeck(1, [{ supportCardId: 20, amount: 1 }]);
+        await expect(bobSignedDeck.removeSupportCardsFromDeck(1, [{supportCardId: 20, amount: 1}])).to.be.revertedWith(
           'PepemonCardDeck: Not your deck'
         );
       });
@@ -202,7 +223,7 @@ describe('::Deck', () => {
     });
 
     describe('reverts if', async () => {
-      it('support card count is lower than min number', async () => {
+      it('support card count is lower than 0', async () => {
         await supportCard.mock.balanceOf.withArgs(alice.address, 20).returns(50);
         await supportCard.mock.balanceOf.withArgs(alice.address, 12).returns(30);
 
@@ -219,10 +240,10 @@ describe('::Deck', () => {
           deck.removeSupportCardsFromDeck(1, [
             {
               supportCardId: 20,
-              amount: 30,
+              amount: 46,
             },
           ])
-        ).to.be.revertedWith('PepemonCardDeck: Deck underflow');
+        ).to.be.reverted;
       });
 
       it('support card count is greater than max number', async () => {


### PR DESCRIPTION
This prevents support cards from getting stuck in the deck.

MIN_SUPPORT_CARDS is kept for use in the matchmaking contract

Also fixed a security issue with adding/removing cards from decks.