### PR TITLE
PvE mode

### DIFF
--- a/contracts/PepemonMatchmaker.sol
+++ b/contracts/PepemonMatchmaker.sol
@@ -50,6 +50,13 @@ contract PepemonMatchmaker is ERC1155Holder, ERC721Holder, AdminRole {
 
     function addPveDeck(uint256 deckId) public onlyAdmin {
         require(_pveMode == true);
+
+        // must be set, unless PvE requires no ranking (to be confirmed)
+        if (playerRanking[msg.sender] == 0) {
+            playerRanking[msg.sender] = _defaultRanking;
+            leaderboardPlayers.push(msg.sender);
+        }
+
         addWaitingDeck(deckId);
     }
 
@@ -294,7 +301,7 @@ contract PepemonMatchmaker is ERC1155Holder, ERC721Holder, AdminRole {
             return 0;
         }
         // Take one of the random pve decks
-        uint256 index = uint256(keccak256(abi.encodePacked(uint256(63), deckId, block.timestamp, block.prevrandao))) % waitingDecks.length;
+        uint256 index = uint256(keccak256(abi.encodePacked(uint256(63), deckId, block.timestamp))) % waitingDecks.length;
         return waitingDecks[index].deckId;
     }
 

--- a/contracts/PepemonMatchmaker.sol
+++ b/contracts/PepemonMatchmaker.sol
@@ -97,7 +97,15 @@ contract PepemonMatchmaker is ERC1155Holder, ERC721Holder, AdminRole {
     function setKFactor(uint256 kFactor) public onlyAdmin {
         _kFactor = kFactor;
     }
-    
+
+    /**
+     * @notice Tells whether or not this contract is operating in PvE mode. When in PvE mode, players cannot fight against
+     * each other (because PvE is the opposite of PvP).
+     */
+    function isPveMode() public view returns(bool) {
+        return _pveMode;
+    }
+
     /**
      * @dev Returns the number of players currently on the leaderboard.
      * @return The number of players currently on the leaderboard.

--- a/test/MatchmakerTest.ts
+++ b/test/MatchmakerTest.ts
@@ -381,7 +381,10 @@ describe('::Matchmaker', () => {
       await matchmaker.setPveMode(true);
       await matchmaker.addPveDeck(aliceDeck);
 
-      await bobSignedMatchmaker.enterPve(bobDeck); // battle begins here
+      // battle 3x in a row
+      await bobSignedMatchmaker.enterPve(bobDeck); 
+      await bobSignedMatchmaker.enterPve(bobDeck);
+      await bobSignedMatchmaker.enterPve(bobDeck);
 
       let aliceRanking = await bobSignedMatchmaker.playerRanking(alice.address);
       let bobRanking = await bobSignedMatchmaker.playerRanking(bob.address);


### PR DESCRIPTION
- Added methods for enabling PvE mode
  - In this mode, players can't join using the "enter" function anymore, they must use "enterPve"
  - Some decks must be set by admins, these decks will be used to fight against players, these decks are picked randomly