### PR TITLE
feat(booster): paid booster packs minting onto the existing card factory

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -9,5 +9,6 @@ export default {
   ftmTestnetApiKey: process.env.FANTOM_API_KEY ?? '',
   infuraKey: process.env.INFURA_API_KEY ?? '',
   alchemyKey: process.env.ALCHEMY_API_KEY ?? '',
+  baseSepoliaRpc: process.env.BASE_SEPOLIA_RPC ?? 'https://sepolia.base.org',
   alchemyRinkebyKey: process.env.ALCHEMY_RINKEBY_API_KEY ?? '',
 };

--- a/contracts/PepemonBoosterPack.sol
+++ b/contracts/PepemonBoosterPack.sol
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
+import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import "./lib/AdminRole.sol";
+
+interface IPepemonCardFaucet {
+    function mintCards() external;
+}
+
+/**
+ * @title PepemonBoosterPack
+ * @dev Paid booster packs that mint onto the game's existing card factory.
+ *
+ * This is deliberately a standalone contract rather than a change to PepemonCardDeck.
+ * PepemonCardDeck is not upgradeable, so adding pack minting there would mean redeploying it
+ * and orphaning every deck NFT already issued, plus the matchmaker's references to them.
+ *
+ * PepemonCardDeck.mintInitialDeck already looks like a booster pack, but it cannot be reused:
+ * on the live deployment its battle card allowlist is empty, its randomness oracle address is
+ * zero, and the factory's batchMintList reverts on every call because it iterates i <= length.
+ * All three were confirmed against Base Sepolia before this contract was written.
+ *
+ * Cards are sourced through PepemonCardDeck.mintCards(), which is permissionless and mints one
+ * of every card id to its caller. That means this contract needs no minter role and no admin
+ * transaction on any existing contract to go live. The trade-off is a hard dependency on that
+ * faucet staying enabled: if an admin ever calls setMintingCards(_, 0), packs stop working and
+ * this contract has to be redeployed against a minter role instead. It holds no player state,
+ * so that redeploy is cheap.
+ */
+contract PepemonBoosterPack is ERC1155Holder, AdminRole {
+    struct Tier {
+        uint128 price;
+        uint8 battleCards;
+        uint8 commonCards;
+        uint8 rareCards;
+        uint8 epicCards;
+        bool enabled;
+    }
+
+    /// @dev The game's card factory. Packs mint here so decks and battles work unchanged.
+    IERC1155 public immutable factory;
+
+    /// @dev PepemonCardDeck, used only for its permissionless mintCards() faucet.
+    IPepemonCardFaucet public immutable cardSource;
+
+    mapping(uint8 => Tier) public tiers;
+
+    uint256[] public battlePool;
+    uint256[] public commonPool;
+    uint256[] public rarePool;
+    uint256[] public epicPool;
+
+    uint256 private nonce;
+
+    event PackOpened(address indexed buyer, uint8 indexed tier, uint256[] cardIds);
+    event TierUpdated(uint8 indexed tier, uint128 price, bool enabled);
+    event PoolsUpdated(uint256 battleCount, uint256 commonCount, uint256 rareCount, uint256 epicCount);
+    event Withdrawn(address indexed to, uint256 amount);
+
+    constructor(address factoryAddress, address cardSourceAddress) {
+        require(factoryAddress != address(0), "PepemonBoosterPack: No factory");
+        require(cardSourceAddress != address(0), "PepemonBoosterPack: No card source");
+        factory = IERC1155(factoryAddress);
+        cardSource = IPepemonCardFaucet(cardSourceAddress);
+    }
+
+    // ---------------------------------------------------------------- purchase
+
+    /**
+     * @dev Buys and immediately opens one pack, transferring the cards to the caller.
+     */
+    function mintPack(uint8 tierId) external payable {
+        // A pack is rolled and revealed inside a single transaction, so a contract caller could
+        // inspect what it drew and revert on a bad roll, paying only gas until it hits an Epic.
+        // Rejecting contract callers removes that option; there is no cheap reroll for an EOA
+        // because the seed moves with every block.
+        require(msg.sender == tx.origin, "PepemonBoosterPack: EOA only");
+
+        Tier memory tier = tiers[tierId];
+        require(tier.enabled, "PepemonBoosterPack: Unknown tier");
+        require(msg.value == tier.price, "PepemonBoosterPack: Incorrect price");
+
+        uint256[] memory cards = _roll(tier, _seed());
+
+        _topUpInventory();
+
+        for (uint256 i = 0; i < cards.length; ++i) {
+            factory.safeTransferFrom(address(this), msg.sender, cards[i], 1, "");
+        }
+
+        emit PackOpened(msg.sender, tierId, cards);
+    }
+
+    // ---------------------------------------------------------------- views
+
+    function packSize(uint8 tierId) public view returns (uint256) {
+        Tier memory tier = tiers[tierId];
+        return uint256(tier.battleCards) + tier.commonCards + tier.rareCards + tier.epicCards;
+    }
+
+    /**
+     * @dev Single-value accessors for the game client.
+     *
+     * The public `tiers` mapping already returns all of this, but as a tuple. Decoding a tuple
+     * in the Unity client needs a Nethereum DTO plus a separate WebGL code path, and WebGL is
+     * the one target that cannot be tested outside a 35-minute cloud build. Reading two plain
+     * uint256 values instead removes that whole class of failure for three lines of Solidity.
+     */
+    function tierPrice(uint8 tierId) external view returns (uint256) {
+        return tiers[tierId].price;
+    }
+
+    function tierEnabled(uint8 tierId) external view returns (bool) {
+        return tiers[tierId].enabled;
+    }
+
+    function getPools()
+        external
+        view
+        returns (
+            uint256[] memory battle,
+            uint256[] memory common,
+            uint256[] memory rare,
+            uint256[] memory epic
+        )
+    {
+        return (battlePool, commonPool, rarePool, epicPool);
+    }
+
+    // ---------------------------------------------------------------- admin
+
+    function setTier(
+        uint8 tierId,
+        uint128 price,
+        uint8 battleCards,
+        uint8 commonCards,
+        uint8 rareCards,
+        uint8 epicCards,
+        bool enabled
+    ) external onlyAdmin {
+        require(battlePool.length >= battleCards, "PepemonBoosterPack: Battle pool too small");
+        require(commonPool.length >= commonCards, "PepemonBoosterPack: Common pool too small");
+        require(rarePool.length >= rareCards, "PepemonBoosterPack: Rare pool too small");
+        require(epicPool.length >= epicCards, "PepemonBoosterPack: Epic pool too small");
+
+        tiers[tierId] = Tier(price, battleCards, commonCards, rareCards, epicCards, enabled);
+        emit TierUpdated(tierId, price, enabled);
+    }
+
+    function setPools(
+        uint256[] calldata battle,
+        uint256[] calldata common,
+        uint256[] calldata rare,
+        uint256[] calldata epic
+    ) external onlyAdmin {
+        battlePool = battle;
+        commonPool = common;
+        rarePool = rare;
+        epicPool = epic;
+        emit PoolsUpdated(battle.length, common.length, rare.length, epic.length);
+    }
+
+    function withdraw(address payable to) external onlyAdmin {
+        require(to != address(0), "PepemonBoosterPack: No recipient");
+        uint256 amount = address(this).balance;
+        (bool sent, ) = to.call{value: amount}("");
+        require(sent, "PepemonBoosterPack: Withdraw failed");
+        emit Withdrawn(to, amount);
+    }
+
+    // ---------------------------------------------------------------- internals
+
+    function _seed() private returns (uint256) {
+        // block.difficulty compiles to opcode 0x44, which on OP-stack chains such as Base
+        // carries the prevrandao value posted from L1. Solidity 0.8.6 predates the prevrandao
+        // alias, so the old name is used for the same opcode.
+        uint256 seed = uint256(
+            keccak256(
+                abi.encodePacked(blockhash(block.number - 1), block.timestamp, block.difficulty, msg.sender, nonce)
+            )
+        );
+        nonce++;
+        return seed;
+    }
+
+    function _roll(Tier memory tier, uint256 seed) private view returns (uint256[] memory) {
+        uint256 total = uint256(tier.battleCards) + tier.commonCards + tier.rareCards + tier.epicCards;
+        require(total > 0, "PepemonBoosterPack: Empty pack");
+
+        uint256[] memory cards = new uint256[](total);
+        uint256 written = 0;
+
+        written = _draw(battlePool, tier.battleCards, seed, 0, cards, written);
+        written = _draw(commonPool, tier.commonCards, seed, 1, cards, written);
+        written = _draw(rarePool, tier.rareCards, seed, 2, cards, written);
+        _draw(epicPool, tier.epicCards, seed, 3, cards, written);
+
+        return cards;
+    }
+
+    /**
+     * @dev Draws `count` distinct ids from `pool` by partial Fisher-Yates over a memory copy.
+     *
+     * Distinctness is what lets _ensureInventory get away with a single faucet top-up: every
+     * card in a pack is needed exactly once, and one mintCards() call adds one of every id.
+     */
+    function _draw(
+        uint256[] storage pool,
+        uint256 count,
+        uint256 seed,
+        uint256 salt,
+        uint256[] memory out,
+        uint256 offset
+    ) private view returns (uint256) {
+        if (count == 0) {
+            return offset;
+        }
+
+        uint256 poolSize = pool.length;
+        require(poolSize >= count, "PepemonBoosterPack: Pool too small");
+
+        uint256[] memory bag = new uint256[](poolSize);
+        for (uint256 i = 0; i < poolSize; ++i) {
+            bag[i] = pool[i];
+        }
+
+        for (uint256 i = 0; i < count; ++i) {
+            uint256 pick = i + (uint256(keccak256(abi.encodePacked(seed, salt, i))) % (poolSize - i));
+            (bag[i], bag[pick]) = (bag[pick], bag[i]);
+            out[offset + i] = bag[i];
+        }
+
+        return offset + count;
+    }
+
+    /**
+     * @dev Tops up inventory from the faucet, unconditionally.
+     *
+     * mintCards() mints one of every card id to this contract, and packs draw distinct cards
+     * from disjoint pools, so one call always covers a whole pack.
+     *
+     * Topping up only when a drawn card happened to be missing would usually be cheaper, but it
+     * put a ~1.7M gas swing on the outcome of the roll. Because the seed moves between a
+     * wallet's gas estimation and execution, a pack estimated against a cheap roll could execute
+     * an expensive one and run out of gas, taking the player's money and giving nothing back.
+     *
+     * Doing it every time does not make gas constant -- measured cost still moves by roughly
+     * 100-400k depending on which storage slots are already warm -- but it removes the large
+     * swing and leaves a residue that a normal estimation buffer covers. Callers should still
+     * send with headroom rather than a bare estimate; see PepemonBoosterPack.cs in the client.
+     */
+    function _topUpInventory() private {
+        cardSource.mintCards();
+    }
+}

--- a/contracts/test/BoosterPackContractBuyer.sol
+++ b/contracts/test/BoosterPackContractBuyer.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IPepemonBoosterPack {
+    function mintPack(uint8 tierId) external payable;
+}
+
+/**
+ * @dev Test-only contract used to prove PepemonBoosterPack rejects contract callers.
+ *
+ * A contract caller is what makes a single-transaction pack roll exploitable: it can inspect
+ * what it drew and revert on a bad roll, paying only gas until it hits an Epic. This exists so
+ * that defence is covered by a test rather than asserted in a comment.
+ */
+contract BoosterPackContractBuyer {
+    function buy(address booster, uint8 tierId) external payable {
+        IPepemonBoosterPack(booster).mintPack{value: msg.value}(tierId);
+    }
+}

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -80,6 +80,11 @@ const config: HardhatUserConfig = {
       url: 'https://rpc.testnet.soniclabs.com',
       accounts: [environment.privateKey ? environment.privateKey : '0'.repeat(64)]
     },
+    base_sepolia: {
+      url: environment.baseSepoliaRpc,
+      chainId: 84532,
+      accounts: [environment.privateKey ? environment.privateKey : '0'.repeat(64)],
+    },
     pepechain_testnet: {
       url: 'https://l2-pepechain-testnet-8uk55qlld4.t.conduit.xyz',
       accounts: [environment.privateKey ? environment.privateKey : '0'.repeat(64)],
@@ -101,9 +106,18 @@ const config: HardhatUserConfig = {
     apiKey: {
       ethereum: environment.etherScanKey,
       pepechain_testnet: "NONE",
+      base_sepolia: "NONE",
       ftmTestnet: environment.ftmTestnetApiKey // get a key from: https://ftmscan.com/myapikey
     },
     customChains: [
+      {
+        network: "base_sepolia",
+        chainId: 84532,
+        urls: {
+          apiURL: "https://base-sepolia.blockscout.com/api",
+          browserURL: "https://base-sepolia.blockscout.com"
+        }
+      },
       {
         network: "pepechain_testnet",
         chainId: 906090,

--- a/scripts/deployBoosterPack.ts
+++ b/scripts/deployBoosterPack.ts
@@ -1,0 +1,103 @@
+import { ethers, network, run } from 'hardhat';
+
+/**
+ * Deploys PepemonBoosterPack and configures its pools and tiers.
+ *
+ * This deliberately needs no privileged key. The booster sources cards through
+ * PepemonCardDeck.mintCards(), which is permissionless, so whoever runs this becomes the
+ * booster's own admin without needing minter or admin rights on any existing contract.
+ *
+ *   PRIVATE_KEY=0x... npx hardhat run scripts/deployBoosterPack.ts --network base_sepolia
+ */
+
+// Live Base Sepolia deployment. Override for other chains.
+const FACTORY = process.env.PEPEMON_FACTORY ?? '0x888c830242caAa352DC506a2C79d38B3e86102aD';
+const CARD_DECK = process.env.PEPEMON_CARD_DECK ?? '0x8D3fc40550a6aBFAa9710A5b256A89bE3324CC0e';
+
+// Card ids grouped by the rarity recorded in deploy/cards.ts. Battle cards are ids 1-10 and are
+// all Common, so they form their own pool rather than being mixed into the common one.
+const BATTLE_POOL = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const COMMON_POOL = [11, 12, 13, 14, 15, 16, 17, 27, 28, 29];
+const RARE_POOL = [18, 19, 20, 21, 22, 25, 30, 31, 32, 33, 34, 36, 37, 40, 41, 42, 43, 44, 46, 47, 48];
+const EPIC_POOL = [23, 24, 26, 35, 38, 39, 45, 49];
+
+// Rarity counts are fixed per tier rather than probabilistic. Every pack is then worth what it
+// advertises, which matters more during onboarding than the thrill of a dud pack. The variety
+// comes from which card of each rarity you draw.
+const TIERS = [
+  { id: 1, name: 'Starter', price: '0.0001', battle: 0, common: 4, rare: 1, epic: 0 },
+  { id: 2, name: 'Trainer', price: '0.0003', battle: 1, common: 5, rare: 3, epic: 1 },
+  { id: 3, name: 'Degen', price: '0.001', battle: 2, common: 8, rare: 7, epic: 3 },
+];
+
+async function main() {
+  const [deployer] = await ethers.getSigners();
+  console.log(`network  : ${network.name}`);
+  console.log(`deployer : ${deployer.address}`);
+  console.log(`balance  : ${ethers.utils.formatEther(await deployer.getBalance())} ETH`);
+
+  // Calling an address with no code succeeds silently, so the faucet check below would pass
+  // against an empty chain and happily deploy a booster wired to nothing.
+  for (const [label, address] of [
+    ['factory', FACTORY],
+    ['card deck', CARD_DECK],
+  ]) {
+    if ((await ethers.provider.getCode(address)) === '0x') {
+      throw new Error(`No contract deployed at ${label} address ${address} on ${network.name}`);
+    }
+  }
+
+  // The booster is useless if the faucet it sources from is switched off, and that failure
+  // would otherwise only show up as a revert on a player's first purchase.
+  const faucet = new ethers.Contract(CARD_DECK, ['function mintCards()'], deployer);
+  try {
+    await faucet.callStatic.mintCards();
+    console.log('faucet   : mintCards() is callable');
+  } catch (e: any) {
+    console.error('\nABORT: PepemonCardDeck.mintCards() reverts, so packs cannot source cards.');
+    console.error('An admin has likely called setMintingCards(_, 0). This contract needs either');
+    console.error('the faucet re-enabled, or a minter role on the factory instead.\n');
+    throw e;
+  }
+
+  const BoosterPack = await ethers.getContractFactory('PepemonBoosterPack');
+  const booster = await BoosterPack.deploy(FACTORY, CARD_DECK);
+  await booster.deployed();
+  console.log(`booster  : ${booster.address}`);
+
+  await (await booster.setPools(BATTLE_POOL, COMMON_POOL, RARE_POOL, EPIC_POOL)).wait();
+  console.log('pools    : configured');
+
+  for (const tier of TIERS) {
+    await (
+      await booster.setTier(
+        tier.id,
+        ethers.utils.parseEther(tier.price),
+        tier.battle,
+        tier.common,
+        tier.rare,
+        tier.epic,
+        true
+      )
+    ).wait();
+    const size = tier.battle + tier.common + tier.rare + tier.epic;
+    console.log(`tier ${tier.id}   : ${tier.name.padEnd(8)} ${tier.price} ETH  ${size} cards`);
+  }
+
+  console.log('\nPaste this address into Web3Settings.pepemonBoosterPackAddress in Unity:');
+  console.log(`  ${booster.address}`);
+
+  if (process.env.ETHERSCAN_API_KEY || network.name === 'base_sepolia') {
+    console.log('\nVerifying on the block explorer...');
+    try {
+      await run('verify:verify', { address: booster.address, constructorArguments: [FACTORY, CARD_DECK] });
+    } catch (e: any) {
+      console.log(`verify skipped: ${e.message}`);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/deployBoosterPack.ts
+++ b/scripts/deployBoosterPack.ts
@@ -30,6 +30,31 @@ const TIERS = [
   { id: 3, name: 'Degen', price: '0.001', battle: 2, common: 8, rare: 7, epic: 3 },
 ];
 
+/**
+ * Blocks until the RPC actually reports code at an address.
+ *
+ * A deployment receipt only proves one node saw the transaction. Public endpoints are load
+ * balanced, so the very next request can hit a node that has not caught up and reports the
+ * address as empty.
+ */
+async function waitForCode(address: string, attempts = 30) {
+  for (let i = 0; i < attempts; i++) {
+    if ((await ethers.provider.getCode(address)) !== '0x') return;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+  }
+  throw new Error(`Timed out waiting for contract code at ${address}`);
+}
+
+/** Sends a configuration transaction and fails loudly if it reverted. */
+async function send(label: string, call: () => Promise<any>) {
+  const tx = await call();
+  const receipt = await tx.wait();
+  if (receipt.status !== 1) {
+    throw new Error(`${label.trim()} FAILED - transaction ${tx.hash} reverted`);
+  }
+  console.log(label);
+}
+
 async function main() {
   const [deployer] = await ethers.getSigners();
   console.log(`network  : ${network.name}`);
@@ -61,27 +86,44 @@ async function main() {
   }
 
   const BoosterPack = await ethers.getContractFactory('PepemonBoosterPack');
-  const booster = await BoosterPack.deploy(FACTORY, CARD_DECK);
-  await booster.deployed();
-  console.log(`booster  : ${booster.address}`);
 
-  await (await booster.setPools(BATTLE_POOL, COMMON_POOL, RARE_POOL, EPIC_POOL)).wait();
-  console.log('pools    : configured');
+  // Set BOOSTER_ADDRESS to configure a contract that is already deployed, rather than paying to
+  // deploy another one. Useful when deployment succeeded but configuration did not.
+  let booster;
+  if (process.env.BOOSTER_ADDRESS) {
+    booster = BoosterPack.attach(process.env.BOOSTER_ADDRESS);
+    console.log(`booster  : ${booster.address} (existing)`);
+  } else {
+    booster = await BoosterPack.deploy(FACTORY, CARD_DECK);
+    await booster.deployed();
+    console.log(`booster  : ${booster.address}`);
+  }
+
+  await waitForCode(booster.address);
+
+  // Explicit gas limits on every configuration call. deployed() resolving is not a promise that
+  // the next JSON-RPC request reaches a node which has the contract: public endpoints such as
+  // sepolia.base.org are load balanced, and an estimate answered by a node that has not caught
+  // up prices the call as a transfer to an empty account, about 41k gas. The transaction is then
+  // sent with that limit and runs out of gas. Fixed limits do not depend on estimation at all.
+  await send('pools    : configured', () =>
+    booster.setPools(BATTLE_POOL, COMMON_POOL, RARE_POOL, EPIC_POOL, { gasLimit: 4000000 })
+  );
 
   for (const tier of TIERS) {
-    await (
-      await booster.setTier(
+    const size = tier.battle + tier.common + tier.rare + tier.epic;
+    await send(`tier ${tier.id}   : ${tier.name.padEnd(8)} ${tier.price} ETH  ${size} cards`, () =>
+      booster.setTier(
         tier.id,
         ethers.utils.parseEther(tier.price),
         tier.battle,
         tier.common,
         tier.rare,
         tier.epic,
-        true
+        true,
+        { gasLimit: 300000 }
       )
-    ).wait();
-    const size = tier.battle + tier.common + tier.rare + tier.epic;
-    console.log(`tier ${tier.id}   : ${tier.name.padEnd(8)} ${tier.price} ETH  ${size} cards`);
+    );
   }
 
   console.log('\nPaste this address into Web3Settings.pepemonBoosterPackAddress in Unity:');

--- a/test/BoosterPackTest.ts
+++ b/test/BoosterPackTest.ts
@@ -1,0 +1,300 @@
+import { ethers } from 'hardhat';
+import { expect } from 'chai';
+import { BigNumber, Contract } from 'ethers';
+
+/**
+ * These tests deploy real PepemonFactory and PepemonCardDeck contracts and drive the booster
+ * through them. Nothing here is mocked: a pack really calls the deck's mintCards() faucet, the
+ * factory really mints 49 ERC1155 ids into the booster, and the booster really transfers cards
+ * out to the buyer.
+ *
+ * Forking Base Sepolia would be better still, but hardhat 2.14 cannot fork OP-stack chains --
+ * it requires totalDifficulty in the block response and no public Base RPC returns it. Bumping
+ * hardhat needs --force against the repo's peer dependencies, which is its own change. The
+ * live-deployment half of the verification was therefore done out of band with eth_call against
+ * Base Sepolia, which confirmed that mintCards() succeeds from an arbitrary caller and that
+ * batchMintList reverts with panic 0x32 on every call.
+ *
+ * That last point is why this contract sources cards the way it does, and why it is worth
+ * saying plainly: the design this replaces was built on PepemonCardDeck.mintInitialDeck, which
+ * reads fine in source but is dead on the live deployment three separate ways. Tests against
+ * mocks would have reproduced the source, passed, and taught us nothing.
+ */
+
+const CARD_COUNT = 49;
+const MAX_SUPPLY = 99999999;
+
+// Card ids grouped by the rarity recorded in deploy/cards.ts. Battle cards are ids 1-10 and are
+// all Common, so they get their own pool rather than being mixed into the common one.
+const BATTLE_POOL = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+const COMMON_POOL = [11, 12, 13, 14, 15, 16, 17, 27, 28, 29];
+const RARE_POOL = [18, 19, 20, 21, 22, 25, 30, 31, 32, 33, 34, 36, 37, 40, 41, 42, 43, 44, 46, 47, 48];
+const EPIC_POOL = [23, 24, 26, 35, 38, 39, 45, 49];
+
+const TIERS = {
+  starter: { id: 1, price: ethers.utils.parseEther('0.0001'), battle: 0, common: 4, rare: 1, epic: 0 },
+  trainer: { id: 2, price: ethers.utils.parseEther('0.0003'), battle: 1, common: 5, rare: 3, epic: 1 },
+  degen: { id: 3, price: ethers.utils.parseEther('0.001'), battle: 2, common: 8, rare: 7, epic: 3 },
+};
+
+describe('::BoosterPack', () => {
+  let booster: Contract;
+  let factory: Contract;
+  let deck: Contract;
+  let admin: any;
+  let buyer: any;
+
+  beforeEach(async function () {
+    this.timeout(180000);
+    [admin, buyer] = await ethers.getSigners();
+
+    const Factory = await ethers.getContractFactory('XPepemonFactory');
+    factory = await Factory.deploy();
+    await factory.deployed();
+
+    // Cards must exist before they can be minted: mintPepe checks tokenMaxSupply. xcreate is
+    // the internal create() surfaced by hardhat-exposed; the lowercase prefix comes from
+    // hardhat.config.tests.ts, which is the config `make test` and CI both use.
+    for (let i = 0; i < CARD_COUNT; i++) {
+      await factory.xcreate(MAX_SUPPLY, 0, '', '0x');
+    }
+
+    const Config = await ethers.getContractFactory('PepemonConfig');
+    const config = await Config.deploy();
+    await config.deployed();
+
+    const Deck = await ethers.getContractFactory('PepemonCardDeck');
+    deck = await Deck.deploy(config.address);
+    await deck.deployed();
+
+    await config.setContractAddress('PepemonFactory', factory.address, false);
+    await deck.syncConfig();
+
+    // Mirrors deploy/005_contract_config.ts, which is what the live deployment ran.
+    await factory.addMinter(deck.address);
+    await deck.setMintingCards(1, CARD_COUNT);
+
+    const BoosterPack = await ethers.getContractFactory('PepemonBoosterPack');
+    booster = await BoosterPack.deploy(factory.address, deck.address);
+    await booster.deployed();
+
+    await booster.setPools(BATTLE_POOL, COMMON_POOL, RARE_POOL, EPIC_POOL);
+    for (const tier of Object.values(TIERS)) {
+      await booster.setTier(tier.id, tier.price, tier.battle, tier.common, tier.rare, tier.epic, true);
+    }
+  });
+
+  // Pack gas is data-dependent, and the seed moves between estimation and execution, so a bare
+  // estimate is sometimes short. Ethers v5 adds no buffer of its own. The client sends with the
+  // same headroom, so the tests buy the way the game does.
+  const GAS_LIMIT = 6000000;
+
+  /** Buys a pack and reads the awarded card ids straight off the PackOpened event. */
+  async function openPack(tier: { id: number; price: BigNumber }, signer = buyer): Promise<number[]> {
+    const tx = await booster.connect(signer).mintPack(tier.id, { value: tier.price, gasLimit: GAS_LIMIT });
+    const receipt = await tx.wait();
+    const event = receipt.events.find((e: any) => e.event === 'PackOpened');
+    expect(event, 'PackOpened was not emitted').to.not.be.undefined;
+    return event.args.cardIds.map((id: BigNumber) => id.toNumber());
+  }
+
+  describe('pack contents', () => {
+    it('delivers a starter pack of the advertised size and rarity mix', async () => {
+      const cards = await openPack(TIERS.starter);
+
+      expect(cards.length).to.eq(5);
+      expect(cards.filter((id) => COMMON_POOL.includes(id)).length).to.eq(4);
+      expect(cards.filter((id) => RARE_POOL.includes(id)).length).to.eq(1);
+    });
+
+    it('delivers a trainer pack including a Pepemon and an Epic', async () => {
+      const cards = await openPack(TIERS.trainer);
+
+      expect(cards.length).to.eq(10);
+      expect(cards.filter((id) => BATTLE_POOL.includes(id)).length).to.eq(1);
+      expect(cards.filter((id) => COMMON_POOL.includes(id)).length).to.eq(5);
+      expect(cards.filter((id) => RARE_POOL.includes(id)).length).to.eq(3);
+      expect(cards.filter((id) => EPIC_POOL.includes(id)).length).to.eq(1);
+    });
+
+    it('delivers a degen pack of 20 cards', async () => {
+      const cards = await openPack(TIERS.degen);
+
+      expect(cards.length).to.eq(20);
+      expect(cards.filter((id) => BATTLE_POOL.includes(id)).length).to.eq(2);
+      expect(cards.filter((id) => COMMON_POOL.includes(id)).length).to.eq(8);
+      expect(cards.filter((id) => RARE_POOL.includes(id)).length).to.eq(7);
+      expect(cards.filter((id) => EPIC_POOL.includes(id)).length).to.eq(3);
+    });
+
+    it('never puts the same card in a pack twice', async () => {
+      const cards = await openPack(TIERS.degen);
+      expect(new Set(cards).size).to.eq(cards.length);
+    });
+
+    it('only ever awards ids that are in a configured pool', async () => {
+      const known = [...BATTLE_POOL, ...COMMON_POOL, ...RARE_POOL, ...EPIC_POOL];
+      const cards = await openPack(TIERS.degen);
+      expect(cards.every((id) => known.includes(id))).to.eq(true);
+    });
+  });
+
+  describe('delivery', () => {
+    it('transfers the cards to the buyer on the game factory', async () => {
+      const ids = [...BATTLE_POOL, ...COMMON_POOL, ...RARE_POOL, ...EPIC_POOL];
+      const owners = ids.map(() => buyer.address);
+      const before: BigNumber[] = await factory.balanceOfBatch(owners, ids);
+
+      const cards = await openPack(TIERS.trainer);
+
+      const after: BigNumber[] = await factory.balanceOfBatch(owners, ids);
+      const gained = ids.filter((id, i) => after[i].gt(before[i]));
+
+      // Every awarded card is a real balance increase, and nothing the pack did not award moved.
+      expect(gained.sort((a, b) => a - b)).to.deep.eq([...cards].sort((a, b) => a - b));
+    });
+
+    it('gives the buyer exactly one of each awarded card', async () => {
+      const cards = await openPack(TIERS.trainer);
+      const owners = cards.map(() => buyer.address);
+      const balances: BigNumber[] = await factory.balanceOfBatch(owners, cards);
+
+      expect(balances.every((b) => b.eq(1))).to.eq(true);
+    });
+
+    it('keeps working across consecutive packs as inventory drains', async function () {
+      this.timeout(300000);
+      for (let i = 0; i < 5; i++) {
+        expect((await openPack(TIERS.degen)).length).to.eq(20);
+      }
+    });
+
+    it('stays inside the gas headroom the client sends', async function () {
+      this.timeout(300000);
+      // Regression test. Inventory used to be topped up only when a drawn card was missing,
+      // which put a ~1.7M gas swing on the outcome of the roll: a pack estimated against a
+      // cheap roll would execute an expensive one and run out of gas, taking the player's money
+      // and giving nothing back. Gas is still data-dependent, so what is asserted here is the
+      // property the client actually relies on -- that a settled pack fits well inside the
+      // limit the game sends -- rather than a constant that would not hold.
+      const used: BigNumber[] = [];
+      for (let i = 0; i < 5; i++) {
+        const tx = await booster.connect(buyer).mintPack(TIERS.degen.id, { value: TIERS.degen.price, gasLimit: GAS_LIMIT });
+        used.push((await tx.wait()).gasUsed);
+      }
+
+      const max = used.reduce((a, b) => (a.gt(b) ? a : b));
+      expect(max.toNumber(), 'a pack must fit inside the gas limit the client sends').to.be.lessThan(GAS_LIMIT);
+
+      // The first pack writes 49 cold storage slots and is by far the most expensive; later
+      // packs settle. If the settled cost ever approached the limit, the client's headroom
+      // would need revisiting rather than this number quietly being raised.
+      const settled = used.slice(1).reduce((a, b) => (a.gt(b) ? a : b));
+      expect(settled.toNumber(), 'settled pack cost drifted; revisit the client gas limit').to.be.lessThan(2500000);
+    });
+
+    it('rolls a different pack each time', async () => {
+      const first = await openPack(TIERS.degen);
+      const second = await openPack(TIERS.degen);
+
+      // Same tier, same buyer, back to back. A static seed would make these identical.
+      expect(first.join(',')).to.not.eq(second.join(','));
+    });
+  });
+
+  describe('payment', () => {
+    it('collects the tier price', async () => {
+      await openPack(TIERS.degen);
+      expect(await ethers.provider.getBalance(booster.address)).to.eq(TIERS.degen.price);
+    });
+
+    it('rejects underpayment', async () => {
+      await expect(
+        booster.connect(buyer).mintPack(TIERS.degen.id, { value: TIERS.starter.price })
+      ).to.be.revertedWith('PepemonBoosterPack: Incorrect price');
+    });
+
+    it('rejects overpayment rather than silently keeping the change', async () => {
+      await expect(
+        booster.connect(buyer).mintPack(TIERS.starter.id, { value: TIERS.degen.price })
+      ).to.be.revertedWith('PepemonBoosterPack: Incorrect price');
+    });
+
+    it('lets an admin withdraw takings', async () => {
+      await openPack(TIERS.degen);
+
+      const before = await ethers.provider.getBalance(buyer.address);
+      await booster.withdraw(buyer.address);
+
+      expect(await ethers.provider.getBalance(booster.address)).to.eq(0);
+      expect(await ethers.provider.getBalance(buyer.address)).to.eq(before.add(TIERS.degen.price));
+    });
+
+    it('refuses withdrawals from non-admins', async () => {
+      await expect(booster.connect(buyer).withdraw(buyer.address)).to.be.reverted;
+    });
+  });
+
+  describe('reroll resistance', () => {
+    it('refuses contract callers, which is what makes a bad roll cheap to discard', async () => {
+      const Buyer = await ethers.getContractFactory('BoosterPackContractBuyer');
+      const contractBuyer = await Buyer.deploy();
+      await contractBuyer.deployed();
+
+      await expect(
+        contractBuyer.buy(booster.address, TIERS.degen.id, { value: TIERS.degen.price })
+      ).to.be.revertedWith('PepemonBoosterPack: EOA only');
+    });
+  });
+
+  describe('tier configuration', () => {
+    it('rejects an unknown tier', async () => {
+      await expect(booster.connect(buyer).mintPack(99, { value: 0 })).to.be.revertedWith(
+        'PepemonBoosterPack: Unknown tier'
+      );
+    });
+
+    it('rejects a disabled tier', async () => {
+      const t = TIERS.starter;
+      await booster.setTier(t.id, t.price, t.battle, t.common, t.rare, t.epic, false);
+
+      await expect(booster.connect(buyer).mintPack(t.id, { value: t.price })).to.be.revertedWith(
+        'PepemonBoosterPack: Unknown tier'
+      );
+    });
+
+    it('refuses a tier that would draw more cards than a pool holds', async () => {
+      // The epic pool has 8 ids, so a tier asking for 9 distinct epics can never be filled.
+      await expect(booster.setTier(9, 0, 0, 0, 0, 9, true)).to.be.revertedWith(
+        'PepemonBoosterPack: Epic pool too small'
+      );
+    });
+
+    it('refuses tier and pool changes from non-admins', async () => {
+      await expect(booster.connect(buyer).setTier(1, 0, 0, 1, 0, 0, true)).to.be.reverted;
+      await expect(booster.connect(buyer).setPools([], [], [], [])).to.be.reverted;
+    });
+
+    it('reports pack size so the client does not have to add the fields up', async () => {
+      expect(await booster.packSize(TIERS.degen.id)).to.eq(20);
+      expect(await booster.packSize(TIERS.starter.id)).to.eq(5);
+    });
+
+    it('exposes price and enabled as plain values the client can read without tuple decoding', async () => {
+      expect(await booster.tierPrice(TIERS.degen.id)).to.eq(TIERS.degen.price);
+      expect(await booster.tierEnabled(TIERS.degen.id)).to.eq(true);
+
+      // An unconfigured tier must read as disabled rather than looking free.
+      expect(await booster.tierPrice(99)).to.eq(0);
+      expect(await booster.tierEnabled(99)).to.eq(false);
+    });
+
+    it('exposes the pools so the client can show odds without hardcoding ids', async () => {
+      const [battle, common, rare, epic] = await booster.getPools();
+      expect(battle.map((b: BigNumber) => b.toNumber())).to.deep.eq(BATTLE_POOL);
+      expect(common.map((b: BigNumber) => b.toNumber())).to.deep.eq(COMMON_POOL);
+      expect(rare.map((b: BigNumber) => b.toNumber())).to.deep.eq(RARE_POOL);
+      expect(epic.map((b: BigNumber) => b.toNumber())).to.deep.eq(EPIC_POOL);
+    });
+  });
+});


### PR DESCRIPTION
Adds `PepemonBoosterPack`, a standalone contract that sells randomised card packs and mints them onto the game's **live** `PepemonFactory` (`0x888c8302…`), so existing decks and battles keep working unchanged.

## Why not extend `PepemonCardDeck`

The obvious plan was to generalise `mintInitialDeck` into a paid `mintPack`. I checked it against Base Sepolia first, and it is **dead on the live deployment three separate ways**:

| Check | Result |
|---|---|
| `allowedInitialDeckBattleCards[0]` | reverts — array empty, so the allowlist check always fails. `deploy/005_contract_config.ts` never calls `setInitialDeckOptions` |
| `randNrGenContract()` | `0x0` — `randSeed()` calls `ChainLinkRngOracle(0)` and reverts |
| `factory.batchMintList([1,2], …)` | **panic 0x32** — `for (i = 0; i <= length; i++)` reads `ids[length]`, one past the end |

That third one is a live bug in `PepemonFactory`: **`batchMintList` can never succeed.** `batchMint(start, end, to)` is fine. Worth a separate fix; this contract just avoids it.

On top of that, `PepemonCardDeck` is not upgradeable, so changing it means a redeploy that orphans every deck NFT already issued and every matchmaker reference to them.

## How this sources cards

Through `PepemonCardDeck.mintCards()`, which is **permissionless** (verified: `eth_call` succeeds from an arbitrary address). So this contract needs **no minter role and no admin transaction on any existing contract** — whoever deploys it becomes its own admin.

The trade-off, stated plainly: it depends on that faucet staying enabled. If an admin ever calls `setMintingCards(_, 0)`, packs stop and this must be redeployed against a minter role instead. It holds no player state, so that redeploy is cheap. The deploy script aborts up front if the faucet is already off.

## Design

Three tiers with **fixed rarity counts** rather than probabilistic odds, so every pack is worth what it advertises — variety comes from *which* card of each rarity you draw, via partial Fisher-Yates.

| Tier | Price | Contents |
|---|---|---|
| Starter | 0.0001 ETH | 4 Common + 1 Rare |
| Trainer | 0.0003 ETH | 1 Pepemon + 5 Common + 3 Rare + 1 Epic |
| Degen | 0.001 ETH | 2 Pepemon + 8 Common + 7 Rare + 3 Epic |

**`mintPack` rejects contract callers.** A pack is rolled and revealed in one transaction, so a contract could inspect the result and revert on a bad roll, paying only gas until it hit an Epic.

**Inventory tops up on every purchase**, not only when a drawn card is missing. The conditional version put a ~1.7M gas swing on the outcome of the roll — and because the seed moves between a wallet's gas estimation and execution, a pack estimated against a cheap roll could execute an expensive one and run out of gas, taking the player's money and giving nothing back. This surfaced as a real intermittent test failure, not a hypothetical.

Randomness is `blockhash + timestamp + block.difficulty + sender + nonce`. `block.difficulty` compiles to opcode `0x44`, which returns prevrandao on Base — verified by `eth_call` state override to return `0x149658cd…`, not the header's `difficulty` field, which is `0x0`. Had it returned the header field, every pack would have rolled identically.

## Tests

`test/BoosterPackTest.ts` — 23 tests. `make test` runs **83 passing**, the 60 that were already there plus these.

Tests deploy **real** `PepemonFactory` and `PepemonCardDeck` contracts, not mocks: a pack really calls the faucet, really mints ERC1155 ids, really transfers them out. Forking Base Sepolia would be better still, but hardhat 2.14 cannot fork OP-stack chains — it requires `totalDifficulty` and no public Base RPC returns it. Bumping hardhat needs `--force` against the repo's peer deps, so that is left as its own change.

## Deploying

Needs no privileged key:

```
PRIVATE_KEY=0x... npx hardhat run scripts/deployBoosterPack.ts --network base_sepolia
```

Nothing here has been deployed. The address it prints goes into `Web3Settings.pepemonBoosterPackAddress` on the Unity side.
